### PR TITLE
Update version to 1.2.0, enhance compatibility, and refine documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,22 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 
 ## [Unreleased]
 ### Added
-- (Planned) GitHub Actions workflow for coding standards / linting
-- (Planned) Screenshots and WordPress.org `readme.txt` format (if published to .org)
+- (Planned) Additional automation or tooling improvements
 
 ### Security
-- (Planned) Additional hardening review
+- (Planned) Further hardening review
+
+## [1.2.0] - 2025-09-18
+### Added
+- WordPress.org compatible `readme.txt`
+- Updated compatibility: WP 6.8, PHP 8.2
+
+### Changed
+- Bumped minimum WordPress requirement to 6.5
+- Bumped minimum PHP requirement to 8.2
+
+### Maintenance
+- Documentation refinements (README normalization)
 
 ## [1.1.1] - 2025-09-18
 ### Added
@@ -30,5 +41,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 - Adds Privacy submenu for Editors when not already exposed by core
 - Temporary request-scoped capability elevation on privacy pages
 
-[Unreleased]: https://github.com/soderlind/editor-can-manage-privacy-options/compare/v1.1.1...HEAD
+[Unreleased]: https://github.com/soderlind/editor-can-manage-privacy-options/compare/v1.2.0...HEAD
+[1.2.0]: https://github.com/soderlind/editor-can-manage-privacy-options/compare/v1.1.1...v1.2.0
 [1.1.1]: https://github.com/soderlind/editor-can-manage-privacy-options/compare/v1.0.0...v1.1.1

--- a/editor-can-manage-privacy-options.php
+++ b/editor-can-manage-privacy-options.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Editor Can Manage Privacy Options
  * Description: Grants WordPress Editors the ability to manage privacy settings and access privacy admin pages.
- * Version: 1.1.1
+ * Version: 1.2.0
  * Author: Per Søderlind
  * Author URI: https://github.com/soderlind
  * Plugin URI: https://github.com/soderlind/editor-can-manage-privacy-options
@@ -24,7 +24,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 // Define plugin constants
-define( 'EDITOR_PRIVACY_MANAGER_VERSION', '1.1.1' );
+define( 'EDITOR_PRIVACY_MANAGER_VERSION', '1.2.0' );
 define( 'EDITOR_PRIVACY_MANAGER_URL', plugin_dir_url( __FILE__ ) );
 define( 'EDITOR_PRIVACY_MANAGER_PATH', plugin_dir_path( __FILE__ ) );
 
@@ -207,9 +207,9 @@ final class Editor_Privacy_Manager {
 		?>
 		<style id="editor-privacy-manager-css" data-epm="1">
 			/* Duplicate Privacy submenu handling:
-																	 * Modern: hide entire LI containing the Privacy link and not first. Fallback hides anchor only.
-																	 * :has() support: Chrome 105+, Safari 15.4+, Firefox (flagged) – fallback keeps UX acceptable.
-																	 */
+																			 * Modern: hide entire LI containing the Privacy link and not first. Fallback hides anchor only.
+																			 * :has() support: Chrome 105+, Safari 15.4+, Firefox (flagged) – fallback keeps UX acceptable.
+																			 */
 			#adminmenu .wp-submenu li:not(.wp-first-item):has(> a[href$="options-privacy.php"]) {
 				display: none !important;
 			}

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Tags: privacy, capabilities, editor, roles, permissions
 Requires at least: 6.5
 Tested up to: 6.8
 Requires PHP: 8.2
-Stable tag: 1.1.1
+Stable tag: 1.2.0
 License: MIT
 License URI: https://opensource.org/licenses/MIT
 
@@ -54,6 +54,12 @@ Yes, but users with network-level capabilities are treated as effectively admin 
 Yes; no permanent role modifications are stored. Adjustments are request-scoped and limited to privacy pages.
 
 == Changelog ==
+= 1.2.0 =
+* Added WordPress.org `readme.txt`
+* Updated compatibility (Tested up to 6.8, PHP 8.2)
+* Raised minimum requirements (WP 6.5, PHP 8.2)
+* Documentation refinements (README cleanup)
+
 = 1.1.1 =
 * Added defensive duplicate Privacy menu cleanup
 * Added multiple CSS injection hooks for edge cases
@@ -64,6 +70,9 @@ Yes; no permanent role modifications are stored. Adjustments are request-scoped 
 * Initial release adding Editor access to Privacy Settings via capability remap
 
 == Upgrade Notice ==
+= 1.2.0 =
+Adds WordPress.org readme, updates compatibility and requirements. Update recommended.
+
 = 1.1.1 =
 Improved duplicate menu handling and refined capability checks. Update recommended.
 


### PR DESCRIPTION
This pull request prepares the plugin for the 1.2.0 release, focusing on compatibility updates, documentation improvements, and raising minimum requirements. It adds a WordPress.org-compatible `readme.txt`, updates compatibility information, and bumps both the minimum WordPress and PHP versions required. The changelog and plugin metadata are updated to reflect these changes.

Release and compatibility updates:

* Bumped plugin version to `1.2.0` in `editor-can-manage-privacy-options.php`, updated `EDITOR_PRIVACY_MANAGER_VERSION` constant, and set the stable tag in `readme.txt` to `1.2.0`. [[1]](diffhunk://#diff-a6e621180754650597a6b890d5adfe22301d1d1c3e5f6ad69f1f3ec7273745d2L5-R5) [[2]](diffhunk://#diff-a6e621180754650597a6b890d5adfe22301d1d1c3e5f6ad69f1f3ec7273745d2L27-R27) [[3]](diffhunk://#diff-9e6e4772050998a5c0dc3c61acf3dab0a7e594566171fa5746d6b62f9598efb6L8-R8)
* Updated compatibility: marked as tested up to WordPress 6.8 and PHP 8.2, and raised minimum requirements to WordPress 6.5 and PHP 8.2 in both `readme.txt` and the changelog. [[1]](diffhunk://#diff-9e6e4772050998a5c0dc3c61acf3dab0a7e594566171fa5746d6b62f9598efb6L8-R8) [[2]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edL9-R24) [[3]](diffhunk://#diff-9e6e4772050998a5c0dc3c61acf3dab0a7e594566171fa5746d6b62f9598efb6R57-R62)

Documentation and changelog:

* Added a WordPress.org-compatible `readme.txt` and included a new changelog section for version 1.2.0, summarizing the changes and improvements. [[1]](diffhunk://#diff-9e6e4772050998a5c0dc3c61acf3dab0a7e594566171fa5746d6b62f9598efb6R57-R62) [[2]](diffhunk://#diff-9e6e4772050998a5c0dc3c61acf3dab0a7e594566171fa5746d6b62f9598efb6R73-R75) [[3]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edL9-R24)
* Refined documentation, including README normalization and changelog link updates. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edL9-R24) [[2]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edL33-R45)